### PR TITLE
Template for Renode emulation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug application in Renode",
+            "type": "cppdbg",
+            "request": "launch",
+            "preLaunchTask": "Run Renode",
+            "postDebugTask": "Close Renode",
+            "miDebuggerServerAddress": "localhost:3333",
+            "cwd": "${workspaceRoot}",
+            "miDebuggerPath": "arm-none-eabi-gdb",
+            "program": "${workspaceRoot}/build/st_c_template.elf",
+            "externalConsole": true
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.associations": {
+        "main.h": "c",
+        "stdio.h": "c"
+    }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,56 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build application",
+            "type": "shell",
+            "command": "make",
+            "args": [
+                "all",
+            ]
+        },
+        {
+            "label": "Run Renode",
+            "type": "shell",
+            "command": "renode",
+            "args": [
+                "--console",
+                "${workspaceFolder}/renode/stm32f4.resc"
+            ],
+            "dependsOn": [
+                "Build application"
+            ],
+            "isBackground": true,
+            "problemMatcher": {
+                "source": "Renode",
+                "pattern": {
+                    "regexp": ""
+                },
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "Renode, version .*",
+                    "endsPattern": ".*GDB server with all CPUs started on port.*"
+                }
+            },
+            "group": "build",
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated"
+            }
+        },
+        {
+            "label": "Close Renode",
+            "command": "echo ${input:terminate}",
+            "type": "shell",
+            "problemMatcher": []
+        }
+    ],
+    "inputs": [
+        {
+            "id": "terminate",
+            "type": "command",
+            "command": "workbench.action.tasks.terminate",
+            "args": "terminateAll"
+        }
+    ]
+}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 RM := rm -rf
 
+TOOLCHAIN = arm-none-eabi
+
 # All of the sources participating in the build are defined here
 OBJS := 
 S_DEPS := 
@@ -17,10 +19,10 @@ BUILD_ARTIFACT_PREFIX :=
 BUILD_ARTIFACT := $(BUILD_ARTIFACT_PREFIX)$(BUILD_ARTIFACT_NAME)$(if $(BUILD_ARTIFACT_EXTENSION),.$(BUILD_ARTIFACT_EXTENSION),)
 
 # Add inputs and outputs from these tool invocations to the build variables 
-EXECUTABLE = build/st_c_template.elf
-MAP_FILE = build/st_c_template.map
+EXECUTABLE = build/$(BUILD_ARTIFACT_NAME).elf
+MAP_FILE = build/$(BUILD_ARTIFACT_NAME).map
 SIZE_OUTPUT = default.size.stdout
-OBJDUMP_LIST = build/st_c_template.list
+OBJDUMP_LIST = build/$(BUILD_ARTIFACT_NAME).list
 
 CFLAGS = -mcpu=cortex-m4 \
 		-T"STM32F401CCUX_FLASH.ld" \
@@ -39,17 +41,17 @@ main-build: $(EXECUTABLE) secondary-outputs
 
 # Tool invocations
 $(EXECUTABLE) $(MAP_FILE): $(OBJS) STM32F401CCUX_FLASH.ld
-	arm-none-eabi-gcc -o $(EXECUTABLE) $(OBJS) $(CFLAGS)
+	$(TOOLCHAIN)-gcc -o $(EXECUTABLE) $(OBJS) $(CFLAGS)
 	@echo 'Finished building target: $@'
 	@echo ' '
 
 $(SIZE_OUTPUT): $(EXECUTABLE)
-	arm-none-eabi-size  $(EXECUTABLE)
+	$(TOOLCHAIN)-size  $(EXECUTABLE)
 	@echo 'Finished building: $@'
 	@echo ' '
 
 $(OBJDUMP_LIST): $(EXECUTABLE)
-	arm-none-eabi-objdump -h -S $(EXECUTABLE) > "$(OBJDUMP_LIST)"
+	$(TOOLCHAIN)-objdump -h -S $(EXECUTABLE) > "$(OBJDUMP_LIST)"
 	@echo 'Finished building: $@'
 	@echo ' '
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
 # ST Template C
+- [ST Template C](#st-template-c)
+  - [Configuration](#configuration)
+  - [Compilation](#compilation)
+  - [Emulation - Renode](#emulation---renode)
+    - [Start Execution and GDB Server on Renode](#start-execution-and-gdb-server-on-renode)
+    - [Debug on VSCode](#debug-on-vscode)
+
 
 This repository contains an template project for an STM32F4XX MCU without the use of STM32 Cube IDE. In future commits it's interesting to configure this repository for Windows systems.
 
@@ -11,7 +18,6 @@ sudo apt-get install gcc-arm-linux-gnueabihf
 ```
 
 ## Compilation
-
 To compile the project, just execute:
 
 ```bash
@@ -24,3 +30,76 @@ make clean
 ```
 
 The compilation output is located on `build`.
+
+## Emulation - Renode
+
+To emulate the system is used Renode (version `1.15.2.6132`).
+
+To describe an MCU is used an `.repl` file. They are inside `renode` directory.
+
+To execute the emulation:
+```bash
+renode --console
+```
+
+On the renode console is needed to create an machine:
+```bash
+mach create
+```
+
+Then, it's necessary to load MCU. In this case: (The `@` symbol search for the renode instalation and for the path where the renode is executed)
+```bash
+machine LoadPlatformDescription @renode/stm32f4.repl
+```
+
+To verify if the MCU Platform was load succesfully use:
+```bash
+peripherals
+```
+It should show all the peripherals and their address
+
+Use `logLevel` (-1, 0, 1, 2) to change the log verbosity on renode.
+```bash
+logLevel 0
+```
+
+Use `logLevel` (-1, 0, 1, 2) to change the log verbosity on renode. And it's possible to log the functions to see the execution trace
+```bash
+logLevel 0
+sysbus.cpu LogFunctionNames true
+```
+
+Finally, it's necessary to load the binary on the machine and then start.
+```bash
+sysbus LoadELF @build/st_c_template.elf
+```
+
+NOTE: It's possible (and better) to run all these Renode commands on a script. The script is: `renode/stm32f4.resc`
+
+The below command automates the execution of all commands above.
+```bash
+renode --console renode/stm32f4.resc
+```
+
+### Start Execution and GDB Server on Renode
+```bash
+machine StartGdbServer 3333
+```
+
+To debug on GDB command line execute:
+```bash
+arm-none-eabi-gdb build/st_c_template.elf
+```
+
+### Debug on VSCode
+
+It was created an debug profile on VSCode on `.vscode` named `Debug application in Renode`. 
+
+
+Notes:
+* It's possible to configure GDB on some TCP port and debug it on GDB outside.
+* It's possible to configure UART/USART to show data received (Prints and IHM should be helpfull).
+* In order to avoid writing this commands all time, it can be used an `.resc` file to automate this.
+* It's possible to write integration tests on Robot to execute some hardware related reoutines.
+* If the `.repl` file does not exist, it should be created one. With this created file, all the peripherals implementation will not be implemented and, if used, should be implemented.
+* Documentation about Renode is on: [Renode Documentation](https://renode.readthedocs.io/en/latest/introduction/demo.html)

--- a/core/app/main.c
+++ b/core/app/main.c
@@ -18,6 +18,7 @@
 /* USER CODE END Header */
 /* Includes ------------------------------------------------------------------*/
 #include "main.h"
+#include <stdio.h>
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
@@ -56,6 +57,12 @@ void SystemClock_Config(void);
 
 /* USER CODE END 0 */
 
+void do_nothing(void)
+{
+  int i =0;
+  i++;
+}
+
 /**
   * @brief  The application entry point.
   * @retval int
@@ -90,9 +97,11 @@ int main(void)
 
   /* Infinite loop */
   /* USER CODE BEGIN WHILE */
+  printf("Hello World\n");
   while (1)
   {
     /* USER CODE END WHILE */
+  do_nothing();
 
     /* USER CODE BEGIN 3 */
   }

--- a/renode/stm32f4.repl
+++ b/renode/stm32f4.repl
@@ -1,0 +1,227 @@
+fsmcBank1: Memory.MappedMemory @ sysbus 0x60000000
+    size: 0x10000000
+
+sram: Memory.MappedMemory @ sysbus 0x20000000
+    size: 0x00040000
+
+flash: Memory.MappedMemory @ sysbus 0x08000000
+    size: 0x200000
+
+flash_controller: MTD.STM32F4_FlashController @ {
+        sysbus 0x40023C00;
+        sysbus new Bus.BusMultiRegistration { address: 0x1FFFC000; size: 0x100; region: "optionBytes" }
+    }
+    flash: flash
+
+usart1: UART.STM32_UART @ sysbus <0x40011000, +0x100>
+    -> nvic@37
+
+usart2: UART.STM32_UART @ sysbus <0x40004400, +0x100>
+    -> nvic@38
+
+usart3: UART.STM32_UART @ sysbus <0x40004800, +0x100>
+    -> nvic@39
+
+uart4: UART.STM32_UART @ sysbus <0x40004C00, +0x100>
+    -> nvic@52
+
+uart5: UART.STM32_UART @ sysbus <0x40005000, +0x100>
+    -> nvic@53
+
+can1: CAN.STMCAN @ sysbus <0x40006400, +0x400>
+    [0-3] -> nvic@[19-22]
+
+can2: CAN.STMCAN @ sysbus <0x40006800, +0x400>
+    [0-3] -> nvic@[63-66]
+    master: can1
+
+nvic: IRQControllers.NVIC @ sysbus 0xE000E000
+    priorityMask: 0xF0
+    systickFrequency: 72000000
+    IRQ -> cpu@0
+
+cpu: CPU.CortexM @ sysbus
+    cpuType: "cortex-m4"
+    nvic: nvic
+
+pwr: Miscellaneous.STM32_PWR @ sysbus 0x40007000
+
+crc: CRC.STM32_CRC @ sysbus 0x40023000
+    series: STM32Series.F4
+
+exti: IRQControllers.STM32F4_EXTI @ sysbus 0x40013C00
+    numberOfOutputLines: 24
+    [0-4] -> nvic@[6-10]
+    [5-9] -> nvicInput23@[0-4]
+    [10-15] -> nvicInput40@[0-5]
+    [16, 17, 18, 22] -> nvic@[1, 41, 42, 3]
+
+nvicInput23: Miscellaneous.CombinedInput @ none
+    numberOfInputs: 5
+    -> nvic@23
+
+nvicInput40: Miscellaneous.CombinedInput @ none
+    numberOfInputs: 6
+    -> nvic@40
+
+gpioPortA: GPIOPort.STM32_GPIOPort @ sysbus <0x40020000, +0x400>
+    modeResetValue: 0xA8000000
+    pullUpPullDownResetValue: 0x64000000
+    numberOfAFs: 16
+    [0-15] -> exti@[0-15]
+
+gpioPortB: GPIOPort.STM32_GPIOPort @ sysbus <0x40020400, +0x400>
+    modeResetValue: 0x00000280
+    outputSpeedResetValue: 0x000000C0
+    pullUpPullDownResetValue: 0x00000100
+    numberOfAFs: 16
+    [0-15] -> exti@[0-15]
+
+gpioPortC: GPIOPort.STM32_GPIOPort @ sysbus <0x40020800, +0x400>
+    numberOfAFs: 16
+    [0-15] -> exti@[0-15]
+
+gpioPortD: GPIOPort.STM32_GPIOPort @ sysbus <0x40020C00, +0x400>
+    numberOfAFs: 16
+    [0-15] -> exti@[0-15]
+
+gpioPortE: GPIOPort.STM32_GPIOPort @ sysbus <0x40021000, +0x400>
+    numberOfAFs: 16
+    [0-15] -> exti@[0-15]
+
+gpioPortF: GPIOPort.STM32_GPIOPort @ sysbus <0x40021400, +0x400>
+    numberOfAFs: 16
+    [0-15] -> exti@[0-15]
+
+ethernet: Network.SynopsysEthernetMAC @ sysbus 0x40028000
+    -> nvic@61
+
+rom1: Memory.MappedMemory @ sysbus 0x1FFF0000
+    size: 0xC000
+
+rom2: Memory.MappedMemory @ sysbus 0x1FFFC400
+    size: 0x3C00
+
+spi1: SPI.STM32SPI @ sysbus 0x40013000
+
+spi2: SPI.STM32SPI @ sysbus 0x40003800
+    IRQ->nvic@35
+    DMARecieve->dma1@3
+
+spi3: SPI.STM32SPI @ sysbus 0x40003C00
+
+i2c1: I2C.STM32F4_I2C @ sysbus 0x40005400
+    EventInterrupt -> nvic@31
+    ErrorInterrupt -> nvic@32
+
+i2c2: I2C.STM32F4_I2C @ sysbus 0x40005800
+    EventInterrupt -> nvic@33
+    ErrorInterrupt -> nvic@34
+
+i2c3: I2C.STM32F4_I2C @ sysbus 0x40005C00
+    EventInterrupt -> nvic@72
+    ErrorInterrupt -> nvic@73
+
+dma1: DMA.STM32DMA @ sysbus 0x40026000
+    [0-7] -> nvic@[11-17,47]
+
+dma2: DMA.STM32DMA @ sysbus 0x40026400
+    [0-7] -> nvic@[56-60,68-70]
+
+rng: Miscellaneous.STM32F4_RNG @ sysbus 0x50060800
+    -> nvic@80
+
+iwdg: Timers.STM32_IndependentWatchdog @ sysbus 0x40003000
+    frequency: 32000
+    windowOption: false
+    defaultPrescaler: 0x4
+
+rtc: Timers.STM32F4_RTC @ sysbus 0x40002800
+    AlarmIRQ -> nvic@41
+
+rcc: Miscellaneous.STM32F4_RCC @ sysbus 0x40023800
+    rtcPeripheral: rtc
+
+timer1: Timers.STM32_Timer @ sysbus 0x40010000
+    -> nvic@25
+    frequency: 10000000
+    initialLimit: 0xFFFF
+
+timer2: Timers.STM32_Timer @ sysbus 0x40000000
+    -> nvic@28
+    frequency: 10000000
+    initialLimit: 0xFFFFFFFF
+
+timer3: Timers.STM32_Timer @ sysbus 0x40000400
+    -> nvic@29
+    frequency: 10000000
+    initialLimit: 0xFFFF
+
+timer4: Timers.STM32_Timer @ sysbus 0x40000800
+    -> nvic@30
+    frequency: 10000000
+    initialLimit: 0xFFFF
+
+timer5: Timers.STM32_Timer @ sysbus 0x40000C00
+    -> nvic@50
+    frequency: 10000000
+    initialLimit: 0xFFFFFFFF
+
+timer6: Timers.STM32_Timer @ sysbus 0x40001000
+    -> nvic@54
+    frequency: 10000000
+    initialLimit: 0xFFFF
+
+timer7: Timers.STM32_Timer @ sysbus 0x40001400
+    -> nvic@55
+    frequency: 10000000
+    initialLimit: 0xFFFF
+
+timer8: Timers.STM32_Timer @ sysbus 0x40010400
+    -> nvic@44
+    frequency: 10000000
+    initialLimit: 0xFFFF
+
+timer9: Timers.STM32_Timer @ sysbus 0x40014000
+    -> nvic@24
+    frequency: 10000000
+    initialLimit: 0xFFFF
+
+timer10: Timers.STM32_Timer @ sysbus 0x40014400
+    -> nvic@25
+    frequency: 10000000
+    initialLimit: 0xFFFF
+
+timer11: Timers.STM32_Timer @ sysbus 0x40014800
+    -> nvic@26
+    frequency: 10000000
+    initialLimit: 0xFFFF
+
+timer12: Timers.STM32_Timer @ sysbus 0x40001800
+    -> nvic@43
+    frequency: 10000000
+    initialLimit: 0xFFFF
+
+timer13: Timers.STM32_Timer @ sysbus 0x40001C00
+    -> nvic@44
+    frequency: 10000000
+    initialLimit: 0xFFFF
+
+timer14: Timers.STM32_Timer @ sysbus 0x40002000
+    -> nvic@45
+    frequency: 10000000
+    initialLimit: 0xFFFF
+
+bitbandPeripherals: Miscellaneous.BitBanding @ sysbus <0x42000000, +0x2000000>
+    peripheralBase: 0x40000000
+
+bitbandSram: Miscellaneous.BitBanding @ sysbus <0x22000000, +0x200000>
+    peripheralBase: 0x20000000
+
+sysbus:
+    init:
+        ApplySVD @https://dl.antmicro.com/projects/renode/svd/STM32F40x.svd.gz
+        Tag <0x40021000, 0x40021003> "GPIOE_MODER" 0xFFFFFFFF
+        Tag <0x40021004, 0x40021007> "GPIOE_OTYPER" 0x00000008
+        // FLASH and USB tags are required for CubeMX-based projects to pass the initialization phase
+        Tag <0x50000010, 0x5000003f> "USB:RESET" 0x80000000

--- a/renode/stm32f4.resc
+++ b/renode/stm32f4.resc
@@ -1,0 +1,6 @@
+using sysbus
+mach create
+machine LoadPlatformDescription @renode/stm32f4.repl
+logLevel 0
+sysbus LoadELF @build/st_c_template.elf
+machine StartGdbServer 3333


### PR DESCRIPTION
- Versioned base MCU description file for STM32F4 (stm32f4.repl).
- Automate Renode commands execution adding the stm32f4.resc file.
- Added Renode automate execution on VSCode.
- Added Renode Debug on VSCode.
- Added documentation on how to properly use Renode to emulate MCU.
- Added some variables to ease makefile readability and maintenance.